### PR TITLE
Remove the `method` attribute in links

### DIFF
--- a/src/Alterway/Bundle/RestHalBundle/ApiResource/Resource.php
+++ b/src/Alterway/Bundle/RestHalBundle/ApiResource/Resource.php
@@ -26,12 +26,11 @@ abstract class Resource implements ResourceInterface
     public function addLink($rel, $route, array $routeParams = array(), array $attributes = array())
     {
         $generatedRoute = $this->generate($route, $routeParams);
-        $methods = $this->router->getRouteCollection()->get($route)->getMethods();
         $this->hal->addLink(
             $rel,
             $generatedRoute,
             null,
-            array_merge($attributes, array('method' => reset($methods)))
+            $attributes
         );
 
         return $this;


### PR DESCRIPTION
The current implementation uses the `Router::getRouteCollection` method, which loads all routes. If you use yaml to define your routes, it will parse all route files, which has a pretty big performance impact on a
large application with many routes.

This method is actually intended to be used to warm up the cache and nothing else (the result is cached in memory, but every request will read the configuration with no cache involved).

See https://github.com/symfony/symfony/issues/7368#issuecomment-14894672 for a discussion on this topic.

We could implement a router that can do what we need efficiently, but given that we don't use the `method` attribute, let's just remove it completely.

Note : Blackfire says that this change leads to a -200ms improvement in an app with 260 routes.